### PR TITLE
Replace langid with py3langid

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 faust_cchardet>=2.1.19
-langid>=1.1.6
+py3langid>=0.3.0
 tqdm>=4.67.1

--- a/twotone/tools/merge.py
+++ b/twotone/tools/merge.py
@@ -1,7 +1,7 @@
 
 import argparse
 import glob
-import langid
+import py3langid as langid
 import logging
 import os
 import shutil


### PR DESCRIPTION
Langid does not build with latest setuptools,
so lets try something less old