### PR TITLE
Fix recursive subtitle search bug

### DIFF
--- a/twotone/tools/merge.py
+++ b/twotone/tools/merge.py
@@ -102,7 +102,7 @@ class Merge(utils.InterruptibleProcess):
 
         for subdir in found_subdirs:
             sub_subtitles = self._recursive_subtitle_search(subdir)
-            subtitles.extend(subtitles)
+            subtitles.extend(sub_subtitles)
 
         return subtitles
 


### PR DESCRIPTION
## Summary
- fix merge tool recursive subtitle search

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cchardet')*

------
https://chatgpt.com/codex/tasks/task_e_68400f1590b083319fc2a9a16a732c48