### PR TITLE
Fix variable typo length

### DIFF
--- a/twotone/tools/merge.py
+++ b/twotone/tools/merge.py
@@ -52,7 +52,7 @@ class Merge(utils.InterruptibleProcess):
                     elif utils.is_subtitle(path):
                         subtitles.append(path)
 
-        # sort both lists by lenght
+        # sort both lists by length
         videos = sorted(videos, reverse = True, key = lambda k: len(k))
         subtitles = sorted(subtitles, reverse = True, key = lambda k: len(k))
 

--- a/twotone/tools/subtitles_fixer.py
+++ b/twotone/tools/subtitles_fixer.py
@@ -34,8 +34,8 @@ class Fixer(utils.InterruptibleProcess):
         timestamps = list(utils.subrip_time_pattern.finditer(content))
         last_timestamp = timestamps[-1]
         time_from, time_to = map(utils.time_to_ms, last_timestamp.groups())
-        lenght = video_track.length
-        new_time_to = min(time_from + 5000, lenght)
+        length = video_track.length
+        new_time_to = min(time_from + 5000, length)
 
         begin_pos = last_timestamp.start(1)
         end_pos = last_timestamp.end(2)
@@ -151,7 +151,7 @@ class Fixer(utils.InterruptibleProcess):
         video_length = video_info.video_tracks[0].length
 
         if video_length is None:
-            self.logger.warning(f"File {video_file} has unknown lenght. Cannot proceed.")
+            self.logger.warning(f"File {video_file} has unknown length. Cannot proceed.")
             return None
 
         broken_subtitiles = []
@@ -163,8 +163,8 @@ class Fixer(utils.InterruptibleProcess):
                 self.logger.warning(f"Cannot analyse subtitle #{i} of {video_file}: unsupported format '{subtitle.format}'")
                 continue
 
-            lenght = subtitle.length
-            if lenght is not None and lenght > video_length * 1.001:                 # use 0.1% error margin as for some reason valid subtitles may appear longer than video
+            length = subtitle.length
+            if length is not None and length > video_length * 1.001:                 # use 0.1% error margin as for some reason valid subtitles may appear longer than video
                 broken_subtitiles.append(i)
 
         if len(broken_subtitiles) == 0:

--- a/twotone/tools/utils.py
+++ b/twotone/tools/utils.py
@@ -159,7 +159,7 @@ def get_video_data(path: str) -> [VideoInfo]:
 
     def get_length(stream) -> int:
         """
-            get lenght in milliseconds
+            get length in milliseconds
         """
         length = None
 

--- a/twotone/tools/utils2/video.py
+++ b/twotone/tools/utils2/video.py
@@ -91,7 +91,7 @@ def get_video_data2(path: str) -> Dict:
 
     def get_length(stream) -> int:
         """
-            get lenght in milliseconds
+            get length in milliseconds
         """
         length = None
 


### PR DESCRIPTION
## Summary
- correct misspelled `lenght` in documentation and variables
- update variable names in subtitles fixer

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'overrides')*

------
https://chatgpt.com/codex/tasks/task_e_68401115b87c83319acaf5bd224bdbe5