### PR TITLE
Introduce subtitle helper for tests

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -167,6 +167,15 @@ def generate_microdvd_subtitles(path: str, length: int, fps: float = 60):
             sf.write(f"{{{e + 1}}}{{{e + 2}}}\n")
 
 
+def write_subtitle(path: str, lines: list[str], *, encoding: str = "utf-8") -> str:
+    with open(path, "w", encoding=encoding) as f:
+        for line in lines:
+            f.write(line)
+            if not line.endswith("\n"):
+                f.write("\n")
+    return path
+
+
 def run_twotone(tool: str, tool_options = [], global_options = []):
     global_options.append("--quiet")
     twotone.twotone.execute([*global_options, tool, *tool_options])

--- a/tests/test_merge_language_detection.py
+++ b/tests/test_merge_language_detection.py
@@ -3,7 +3,7 @@ import os
 import unittest
 
 from twotone.tools.utils import video_utils
-from common import WorkingDirectoryForTest, list_files, add_test_media, run_twotone
+from common import WorkingDirectoryForTest, list_files, add_test_media, run_twotone, write_subtitle
 
 
 class SimpleSubtitlesMerge(unittest.TestCase):
@@ -12,9 +12,13 @@ class SimpleSubtitlesMerge(unittest.TestCase):
         with WorkingDirectoryForTest() as td:
             add_test_media("Frog.*mp4", td.path)
 
-            with open(os.path.join(td.path, "Frog.txt"), "w") as sf:
-                sf.write("00:00:00:Hello World\n")
-                sf.write("00:00:06:This is some sample subtitle in english\n")
+            write_subtitle(
+                os.path.join(td.path, "Frog.txt"),
+                [
+                    "00:00:00:Hello World",
+                    "00:00:06:This is some sample subtitle in english",
+                ],
+            )
 
             run_twotone("merge", [td.path, "-l", "auto"], ["--no-dry-run"])
 
@@ -32,9 +36,13 @@ class SimpleSubtitlesMerge(unittest.TestCase):
         with WorkingDirectoryForTest() as td:
             add_test_media("Frog.*mp4", td.path)
 
-            with open(os.path.join(td.path, "Frog.txt"), "w") as sf:
-                sf.write("00:00:00:Witaj Świecie\n")
-                sf.write("00:00:06:To jest przykładowy tekst po polsku\n")
+            write_subtitle(
+                os.path.join(td.path, "Frog.txt"),
+                [
+                    "00:00:00:Witaj Świecie",
+                    "00:00:06:To jest przykładowy tekst po polsku",
+                ],
+            )
 
             run_twotone("merge", [td.path, "-l", "auto"], ["--no-dry-run"])
 
@@ -51,25 +59,45 @@ class SimpleSubtitlesMerge(unittest.TestCase):
     def test_language_priority(self):
         with WorkingDirectoryForTest() as td:
             add_test_media("close-up-of-flowers.*mp4", td.path)
-            with open(os.path.join(td.path, "close-up-of-flowers_en.srt"), "w") as sf:
-                sf.write("00:00:00:Hello World\n")
-                sf.write("00:00:06:This is some sample subtitle in english\n")
+            write_subtitle(
+                os.path.join(td.path, "close-up-of-flowers_en.srt"),
+                [
+                    "00:00:00:Hello World",
+                    "00:00:06:This is some sample subtitle in english",
+                ],
+            )
 
-            with open(os.path.join(td.path, "close-up-of-flowers_pl.srt"), "w") as sf:
-                sf.write("00:00:00:Witaj Świecie\n")
-                sf.write("00:00:06:To jest przykładowy tekst po polsku\n")
+            write_subtitle(
+                os.path.join(td.path, "close-up-of-flowers_pl.srt"),
+                [
+                    "00:00:00:Witaj Świecie",
+                    "00:00:06:To jest przykładowy tekst po polsku",
+                ],
+            )
 
-            with open(os.path.join(td.path, "close-up-of-flowers_de.srt"), "w") as sf:
-                sf.write("00:00:00:Hallo Welt\n")
-                sf.write("00:00:06:Dies ist ein Beispiel für einen Untertitel auf Deutsch\n")
+            write_subtitle(
+                os.path.join(td.path, "close-up-of-flowers_de.srt"),
+                [
+                    "00:00:00:Hallo Welt",
+                    "00:00:06:Dies ist ein Beispiel für einen Untertitel auf Deutsch",
+                ],
+            )
 
-            with open(os.path.join(td.path, "close-up-of-flowers_cz.srt"), "w") as sf:
-                sf.write("00:00:00:Ahoj světe\n")
-                sf.write("00:00:06:Toto je ukázka titulků v češtině\n")
+            write_subtitle(
+                os.path.join(td.path, "close-up-of-flowers_cz.srt"),
+                [
+                    "00:00:00:Ahoj světe",
+                    "00:00:06:Toto je ukázka titulků v češtině",
+                ],
+            )
 
-            with open(os.path.join(td.path, "close-up-of-flowers_fr.srt"), "w") as sf:
-                sf.write("00:00:00:Bonjour le monde\n")
-                sf.write("00:00:06:Ceci est un exemple de sous-titre en français\n")
+            write_subtitle(
+                os.path.join(td.path, "close-up-of-flowers_fr.srt"),
+                [
+                    "00:00:00:Bonjour le monde",
+                    "00:00:06:Ceci est un exemple de sous-titre en français",
+                ],
+            )
 
             run_twotone("merge", [td.path, "-l", "auto", "-p" "de,cs"], ["--no-dry-run"])
 

--- a/tests/test_merge_subtitles.py
+++ b/tests/test_merge_subtitles.py
@@ -5,7 +5,7 @@ import re
 import unittest
 
 from twotone.tools.utils import files_utils, video_utils
-from common import WorkingDirectoryForTest, list_files, add_test_media, hashes, run_twotone
+from common import WorkingDirectoryForTest, list_files, add_test_media, hashes, run_twotone, write_subtitle
 
 default_video_set = [
     "Atoms - 8579.mp4",
@@ -164,13 +164,22 @@ class SubtitlesMerge(unittest.TestCase):
         with WorkingDirectoryForTest() as td:
             add_test_media("Frog.*mp4", td.path)
 
-            with open(os.path.join(td.path, "Frog_en.srt"), "w") as sf:
-                sf.write("00:00:00:Hello World\n")
-                sf.write("00:00:06:This is some sample subtitle in english\n")
+            write_subtitle(
+                os.path.join(td.path, "Frog_en.srt"),
+                [
+                    "00:00:00:Hello World",
+                    "00:00:06:This is some sample subtitle in english",
+                ],
+            )
 
-            with open(os.path.join(td.path, "Frog_pl.srt"), "w", encoding="cp1250") as sf:
-                sf.write("00:00:00:Witaj Świecie\n")
-                sf.write("00:00:06:To jest przykładowy tekst po polsku\n")
+            write_subtitle(
+                os.path.join(td.path, "Frog_pl.srt"),
+                [
+                    "00:00:00:Witaj Świecie",
+                    "00:00:06:To jest przykładowy tekst po polsku",
+                ],
+                encoding="cp1250",
+            )
 
             run_twotone("merge", [td.path], ["--no-dry-run"])
 

--- a/tests/test_subtitles_fixer.py
+++ b/tests/test_subtitles_fixer.py
@@ -5,7 +5,15 @@ import tempfile
 
 from twotone.tools.utils import subtitles_utils, video_utils
 
-from common import WorkingDirectoryForTest, add_test_media, hashes, current_path, generate_microdvd_subtitles, run_twotone
+from common import (
+    WorkingDirectoryForTest,
+    add_test_media,
+    hashes,
+    current_path,
+    generate_microdvd_subtitles,
+    run_twotone,
+    write_subtitle,
+)
 from twotone.tools.utils import generic_utils, process_utils
 
 
@@ -37,14 +45,18 @@ def create_broken_video_with_too_long_last_subtitle(output_video_path: str, inpu
         length = default_video_track.length
 
         subtitle_path = f"{subtitle_dir}/sub.srt"
-        with open(subtitle_path, 'w', encoding='utf-8') as file:
-            file.write(f"1\n")
-            file.write(f"{generic_utils.ms_to_time(0)} --> {generic_utils.ms_to_time(1000)}\n")
-            file.write(f"1\n\n")
-
-            file.write(f"2\n")
-            file.write(f"{generic_utils.ms_to_time(1000)} --> {generic_utils.ms_to_time((length + 10) * 1000)}\n")
-            file.write(f"2\n")
+        write_subtitle(
+            subtitle_path,
+            [
+                "1",
+                f"{generic_utils.ms_to_time(0)} --> {generic_utils.ms_to_time(1000)}",
+                "1",
+                "",
+                "2",
+                f"{generic_utils.ms_to_time(1000)} --> {generic_utils.ms_to_time((length + 10) * 1000)}",
+                "2",
+            ],
+        )
 
         video_utils.generate_mkv(input_video = input_video, output_path = output_video_path, subtitles = [subtitles_utils.SubtitleFile(subtitle_path, "eng", "utf8")])
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ import os
 import unittest
 
 from twotone.tools.utils import subtitles_utils
-from common import WorkingDirectoryForTest
+from common import WorkingDirectoryForTest, write_subtitle
 
 
 class UtilsTests(unittest.TestCase):
@@ -12,8 +12,7 @@ class UtilsTests(unittest.TestCase):
         with WorkingDirectoryForTest() as wd:
             subtitle_path = os.path.join(wd.path, "subtitle.txt")
 
-            with open(subtitle_path, 'w') as subtitle_file:
-                subtitle_file.write(content)
+            write_subtitle(subtitle_path, [content])
 
             if valid:
                 self.assertTrue(subtitles_utils.is_subtitle(subtitle_path))


### PR DESCRIPTION
## Summary
- add `write_subtitle` helper in `tests/common.py`
- refactor tests to use the new helper

## Testing
- `PYTHONPATH=$PWD pytest -q` *(fails: ModuleNotFoundError: No module named 'overrides')*

------
https://chatgpt.com/codex/tasks/task_e_6856dceb18a88331bad03e15eedcdea5