### PR TITLE
Add subtitle extraction helper for tests

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -6,19 +6,20 @@ import re
 import shutil
 import tempfile
 
+
+from contextlib import contextmanager
 from pathlib import Path
 from platformdirs import user_cache_dir
 from typing import Dict, List, Union
+from unittest.mock import patch
 
 import twotone.twotone
-import twotone.tools.utils.generic_utils
-from contextlib import contextmanager
-from unittest.mock import patch
-from twotone.tools.utils import files_utils, process_utils
+
+from twotone.tools.utils import files_utils, generic_utils, process_utils
 
 
 current_path = os.path.dirname(os.path.abspath(__file__))
-twotone.tools.utils.generic_utils.DISABLE_PROGRESSBARS = True
+generic_utils.DISABLE_PROGRESSBARS = True
 
 
 class WorkingDirectoryForTest:
@@ -177,6 +178,10 @@ def write_subtitle(path: str, lines: list[str], *, encoding: str = "utf-8") -> s
             if not line.endswith("\n"):
                 f.write("\n")
     return path
+
+
+def extract_subtitles(video_path: str, out_path: str):
+    process_utils.start_process("ffmpeg", ["-i", video_path, "-map", "0:s:0", out_path])
 
 
 def run_twotone(tool: str, tool_options = [], global_options = []):

--- a/tests/test_merge_subtitles_conversion.py
+++ b/tests/test_merge_subtitles_conversion.py
@@ -3,7 +3,7 @@ import os
 import unittest
 
 from twotone.tools.utils import process_utils, subtitles_utils, generic_utils
-from common import WorkingDirectoryForTest, list_files, add_test_media, generate_microdvd_subtitles, run_twotone
+from common import WorkingDirectoryForTest, list_files, add_test_media, generate_microdvd_subtitles, run_twotone, extract_subtitles
 
 
 class SubtitlesConversion(unittest.TestCase):
@@ -22,7 +22,7 @@ class SubtitlesConversion(unittest.TestCase):
             video = files_after[0]
 
             subtitles_path = os.path.join(td.path, "subtitles.srt")
-            process_utils.start_process("ffmpeg", ["-i", video, "-map", "0:s:0", subtitles_path])
+            extract_subtitles(video, subtitles_path)
 
             lines = 0
             with open(subtitles_path, mode='r') as subtitles_file:
@@ -56,7 +56,7 @@ class SubtitlesConversion(unittest.TestCase):
             video = files_after[0]
 
             subtitles_path = os.path.join(td.path, "subtitles.srt")
-            process_utils.start_process("ffmpeg", ["-i", video, "-map", "0:s:0", subtitles_path])
+            extract_subtitles(video, subtitles_path)
 
             lines = 0
             with open(subtitles_path, mode='r') as subtitles_file:


### PR DESCRIPTION
## Summary
- add `extract_subtitles` helper to tests' common utilities
- refactor subtitle conversion tests to use the new helper

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement faust_cchardet)*
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'cchardet')*

------
https://chatgpt.com/codex/tasks/task_e_6856dcf90678833190a5b2dd114948b5