### PR TITLE
Refactor failing process tests

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -12,6 +12,9 @@ from typing import Dict, List, Union
 
 import twotone.twotone
 import twotone.tools.utils.generic_utils
+from contextlib import contextmanager
+from unittest.mock import patch
+from twotone.tools.utils import files_utils, process_utils
 
 
 current_path = os.path.dirname(os.path.abspath(__file__))
@@ -170,3 +173,17 @@ def generate_microdvd_subtitles(path: str, length: int, fps: float = 60):
 def run_twotone(tool: str, tool_options = [], global_options = []):
     global_options.append("--quiet")
     twotone.twotone.execute([*global_options, tool, *tool_options])
+
+
+@contextmanager
+def simulate_process_failure(target_exec: str):
+    original = process_utils.start_process
+
+    def wrapper(cmd, args):
+        _, exec_name, _ = files_utils.split_path(cmd)
+        if exec_name == target_exec:
+            return process_utils.ProcessResult(1, b"", b"")
+        return original(cmd, args)
+
+    with patch("twotone.tools.utils.process_utils.start_process", side_effect=wrapper) as p:
+        yield p

--- a/tests/test_merge_errors_reaction.py
+++ b/tests/test_merge_errors_reaction.py
@@ -1,33 +1,17 @@
-
 import logging
 import unittest
 
-from common import WorkingDirectoryForTest, add_test_media, hashes, run_twotone
-from unittest.mock import patch
-
-from twotone.tools.utils import files_utils, process_utils
-
+from common import WorkingDirectoryForTest, add_test_media, hashes, run_twotone, simulate_process_failure
 
 class SimpleSubtitlesMerge(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls._start_process = process_utils.start_process
         logging.getLogger().setLevel(logging.CRITICAL)
 
 
     def test_no_changes_when_mkvmerge_exits_with_error(self):
-
-        def start_process(cmd, args):
-            _, exec_name, _ = files_utils.split_path(cmd)
-
-            if exec_name == "mkvmerge":
-                return process_utils.ProcessResult(1, b"", b"")
-            else:
-                return self._start_process.__func__(cmd, args)
-
-        with patch("twotone.tools.utils.process_utils.start_process") as mock_start_process, WorkingDirectoryForTest() as td:
-            mock_start_process.side_effect = start_process
+        with simulate_process_failure("mkvmerge") as mock_start_process, WorkingDirectoryForTest() as td:
             add_test_media("Blue_Sky_and_Clouds_Timelapse.*(?:mov|srt)", td.path)
 
             hashes_before = hashes(td.path)
@@ -44,17 +28,7 @@ class SimpleSubtitlesMerge(unittest.TestCase):
 
 
     def test_no_changes_when_ffprobe_exits_with_error(self):
-
-        def start_process(cmd, args):
-            _, exec_name, _ = files_utils.split_path(cmd)
-
-            if exec_name == "ffprobe":
-                return process_utils.ProcessResult(1, b"", b"")
-            else:
-                return self._start_process.__func__(cmd, args)
-
-        with patch("twotone.tools.utils.process_utils.start_process") as mock_start_process, WorkingDirectoryForTest() as td:
-            mock_start_process.side_effect = start_process
+        with simulate_process_failure("ffprobe") as mock_start_process, WorkingDirectoryForTest() as td:
             add_test_media("Blue_Sky_and_Clouds_Timelapse.*(?:mov|srt)", td.path)
 
             hashes_before = hashes(td.path)
@@ -70,17 +44,7 @@ class SimpleSubtitlesMerge(unittest.TestCase):
             self.assertEqual(mock_start_process.call_count, 1)
 
     def test_no_changes_when_ffmpeg_exits_with_error(self):
-
-        def start_process(cmd, args):
-            _, exec_name, _ = files_utils.split_path(cmd)
-
-            if exec_name == "ffmpeg":
-                return process_utils.ProcessResult(1, b"", b"")
-            else:
-                return self._start_process.__func__(cmd, args)
-
-        with patch("twotone.tools.utils.process_utils.start_process") as mock_start_process, WorkingDirectoryForTest() as td:
-            mock_start_process.side_effect = start_process
+        with simulate_process_failure("ffmpeg") as mock_start_process, WorkingDirectoryForTest() as td:
             add_test_media("Blue_Sky_and_Clouds_Timelapse.*(?:mov|srt)", td.path)
 
             hashes_before = hashes(td.path)


### PR DESCRIPTION
## Summary
- simplify error-handling tests with `simulate_process_failure` context manager
- add helper in tests/common for simulating external command failures

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'twotone')*

------
https://chatgpt.com/codex/tasks/task_e_6856dd10f21483318a0e92c172d5e046