### PR TITLE
Add mypy workflow

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,27 @@
+name: Linux-mypy
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  Mypy:
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+        lfs: true
+
+    - name: Install Python dependencies
+      uses: py-actions/py-dependency-install@v4
+      with:
+        path: "requirements.txt"
+        additional_requirements: "mypy"
+
+    - name: Run mypy
+      run: |
+        mypy twotone tests


### PR DESCRIPTION
## Summary
- add workflow to run mypy

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to pypi.org)*
- `mypy twotone tests` *(fails: many import-not-found errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d7abb92108331bbf7b116ceb786a6