### PR TITLE
Remove duplicate classes and checks

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -166,11 +166,11 @@ def assert_video_info(testcase: unittest.TestCase, path: str,
                       expected_video_tracks: int = 1,
                       expected_subtitles: int | None = None):
     testcase.assertTrue(path.endswith(".mkv"))
-    tracks = video_utils.get_video_data(path)
-    testcase.assertEqual(len(tracks.video_tracks), expected_video_tracks)
+    info = video_utils.get_video_data(path)
+    testcase.assertEqual(len(info["video"]), expected_video_tracks)
     if expected_subtitles is not None:
-        testcase.assertEqual(len(tracks.subtitles), expected_subtitles)
-    return tracks
+        testcase.assertEqual(len(info.get("subtitle", [])), expected_subtitles)
+    return info
 
 
 def hashes(path: str) -> Dict[str, str]:

--- a/tests/test_melt.py
+++ b/tests/test_melt.py
@@ -186,7 +186,7 @@ class MeltingTest(WorkingDirectoryTestCase):
 
         output_file = list(output_file_hash)[0]
 
-        output_file_data = video_utils.get_video_data2(output_file)
+        output_file_data = video_utils.get_video_data(output_file)
         self.assertEqual(len(output_file_data["video"]), 1)
         self.assertEqual(output_file_data["video"][0]["height"], 1080)
         self.assertEqual(output_file_data["video"][0]["width"], 1920)
@@ -231,7 +231,7 @@ class MeltingTest(WorkingDirectoryTestCase):
             output_file_name = os.path.basename(output_file)
             self.assertEqual(output_file_name, f"Grass - 66810-suf-S1E{i}.mkv")
 
-            output_file_data = video_utils.get_video_data2(output_file)
+            output_file_data = video_utils.get_video_data(output_file)
             self.assertEqual(len(output_file_data["video"]), 1)
             self.assertEqual(output_file_data["video"][0]["height"], 2160)
             self.assertEqual(output_file_data["video"][0]["width"], 3840)
@@ -262,7 +262,7 @@ class MeltingTest(WorkingDirectoryTestCase):
         self.assertEqual(len(output_file_hash), 1)
 
         output_file = list(output_file_hash)[0]
-        output_file_data = video_utils.get_video_data2(output_file)
+        output_file_data = video_utils.get_video_data(output_file)
         self.assertEqual(output_file_data["audio"][0]["language"], "deu")
         self.assertEqual(output_file_data["audio"][1]["language"], "jpn")
         self.assertEqual(output_file_data["audio"][2]["language"], "eng")

--- a/tests/test_subtitles_fixer.py
+++ b/tests/test_subtitles_fixer.py
@@ -20,13 +20,13 @@ from twotone.tools.utils import generic_utils, process_utils
 def create_broken_video_with_scaled_subtitle_timings(output_video_path: str, input_video: str):
     with tempfile.TemporaryDirectory() as subtitle_dir:
         input_video_info = video_utils.get_video_data(input_video)
-        default_video_track = input_video_info.video_tracks[0]
-        fps = generic_utils.fps_str_to_float(default_video_track.fps)
+        default_video_track = input_video_info["video"][0]
+        fps = generic_utils.fps_str_to_float(default_video_track["fps"])
 
         if abs(fps - subtitles_utils.ffmpeg_default_fps) < 1:
             raise RuntimeError("source video is not suitable, has nearly default fps")
 
-        length = default_video_track.length / 1000
+        length = default_video_track["length"] / 1000
 
         subtitle_path = f"{subtitle_dir}/sub.sub"
         generate_microdvd_subtitles(subtitle_path, int(length), fps)
@@ -41,8 +41,8 @@ def create_broken_video_with_scaled_subtitle_timings(output_video_path: str, inp
 def create_broken_video_with_too_long_last_subtitle(output_video_path: str, input_video: str):
     with tempfile.TemporaryDirectory() as subtitle_dir:
         input_video_info = video_utils.get_video_data(input_video)
-        default_video_track = input_video_info.video_tracks[0]
-        length = default_video_track.length
+        default_video_track = input_video_info["video"][0]
+        length = default_video_track["length"]
 
         subtitle_path = f"{subtitle_dir}/sub.srt"
         write_subtitle(
@@ -64,13 +64,13 @@ def create_broken_video_with_too_long_last_subtitle(output_video_path: str, inpu
 def create_broken_video_with_incompatible_subtitles(output_video_path: str, input_video: str):
     with tempfile.TemporaryDirectory() as subtitle_dir:
         input_video_info = video_utils.get_video_data(input_video)
-        default_video_track = input_video_info.video_tracks[0]
-        fps = generic_utils.fps_str_to_float(default_video_track.fps)
+        default_video_track = input_video_info["video"][0]
+        fps = generic_utils.fps_str_to_float(default_video_track["fps"])
 
         if abs(fps - subtitles_utils.ffmpeg_default_fps) < 1:
             raise RuntimeError("source video is not suitable, has nearly default fps")
 
-        length = default_video_track.length
+        length = default_video_track["length"]
 
         subtitle_path = f"{subtitle_dir}/sub.sub"
         generate_microdvd_subtitles(subtitle_path, int(length), fps)

--- a/twotone/tools/melt/melt.py
+++ b/twotone/tools/melt/melt.py
@@ -227,7 +227,7 @@ class Melter():
         self.logger.info("------------------------------------")
 
         # analyze files in terms of quality and available content
-        details = {file: video_utils.get_video_data2(file) for file in duplicates}
+        details = {file: video_utils.get_video_data(file) for file in duplicates}
 
         common_prefix = files_utils.get_common_prefix(duplicates)
 

--- a/twotone/tools/melt/pair_matcher.py
+++ b/twotone/tools/melt/pair_matcher.py
@@ -24,8 +24,8 @@ class PairMatcher:
         self.rhs_path = rhs_path
         self.logger = logger
         self.phash = PhashCache()
-        self.lhs_fps = eval(video_utils.get_video_data2(lhs_path)["video"][0]["fps"])
-        self.rhs_fps = eval(video_utils.get_video_data2(rhs_path)["video"][0]["fps"])
+        self.lhs_fps = eval(video_utils.get_video_data(lhs_path)["video"][0]["fps"])
+        self.rhs_fps = eval(video_utils.get_video_data(rhs_path)["video"][0]["fps"])
 
         lhs_wd = os.path.join(self.wd, "lhs")
         rhs_wd = os.path.join(self.wd, "rhs")

--- a/twotone/tools/merge.py
+++ b/twotone/tools/merge.py
@@ -192,7 +192,7 @@ class Merge(generic_utils.InterruptibleProcess):
 
                 # Subtitles are buggy sometimes, use ffmpeg to fix them.
                 # Also makemkv does not handle MicroDVD subtitles, so convert all to SubRip.
-                fps = input_file_details.video_tracks[0].fps
+                fps = input_file_details["video"][0]["fps"]
                 converted_subtitle = self._convert_subtitle(fps, subtitle, temporary_subtitles_dir)
 
                 prepared_subtitles.append(converted_subtitle)
@@ -297,12 +297,7 @@ class MergeTool(Tool):
 
     @override
     def run(self, args: argparse.Namespace, no_dry_run: bool, logger: logging.Logger) -> None:
-        for tool in ["mkvmerge", "ffmpeg", "ffprobe"]:
-            path = shutil.which(tool)
-            if path is None:
-                raise RuntimeError(f"{tool} not found in PATH")
-            else:
-                logger.debug(f"{tool} path: {path}")
+        process_utils.ensure_tools_exist(["mkvmerge", "ffmpeg", "ffprobe"], logger)
 
         logger.info("Searching for movie and subtitle files to be merged")
         two_tone = Merge(logger,

--- a/twotone/tools/subtitles_fixer.py
+++ b/twotone/tools/subtitles_fixer.py
@@ -19,20 +19,20 @@ class Fixer(generic_utils.InterruptibleProcess):
         self.logger = logger
         self._do_fix = really_fix
 
-    def _print_broken_videos(self, broken_videos_info: list[tuple[video_utils.VideoInfo, list[int]]]) -> None:
+    def _print_broken_videos(self, broken_videos_info: list[tuple[dict, list[int]]]) -> None:
         self.logger.info(f"Found {len(broken_videos_info)} broken videos:")
         for broken_video in broken_videos_info:
-            self.logger.info(f"{len(broken_video[1])} broken subtitle(s) in {broken_video[0].path} found")
+            self.logger.info(f"{len(broken_video[1])} broken subtitle(s) in {broken_video[0]['path']} found")
 
-    def _no_resolver(self, video_track: video_utils.VideoTrack, content: str) -> None:
+    def _no_resolver(self, video_track: dict, content: str) -> None:
         self.logger.error("Cannot fix the file, no idea how to do it.")
         return None
 
-    def _long_tail_resolver(self, video_track: video_utils.VideoTrack, content: str) -> str:
+    def _long_tail_resolver(self, video_track: dict, content: str) -> str:
         timestamps = list(subtitles_utils.subrip_time_pattern.finditer(content))
         last_timestamp = timestamps[-1]
         time_from, time_to = map(generic_utils.time_to_ms, last_timestamp.groups())
-        length = video_track.length
+        length = video_track["length"]
         new_time_to = min(time_from + 5000, length)
 
         begin_pos = last_timestamp.start(1)
@@ -41,13 +41,13 @@ class Fixer(generic_utils.InterruptibleProcess):
         content = content[:begin_pos] + f"{generic_utils.ms_to_time(time_from)} --> {generic_utils.ms_to_time(new_time_to)}" + content[end_pos:]
         return content
 
-    def _fps_scale_resolver(self, video_track: video_utils.VideoTrack, content: str) -> str:
-        target_fps = generic_utils.fps_str_to_float(video_track.fps)
+    def _fps_scale_resolver(self, video_track: dict, content: str) -> str:
+        target_fps = generic_utils.fps_str_to_float(video_track["fps"])
         multiplier = subtitles_utils.ffmpeg_default_fps / target_fps
 
         return subtitles_utils.alter_subrip_subtitles_times(content, multiplier)
 
-    def _get_resolver(self, content: str, video_length: int) -> Callable[[video_utils.VideoTrack, str], str | None]:
+    def _get_resolver(self, content: str, video_length: int) -> Callable[[dict, str], str | None]:
         timestamps = list(subtitles_utils.subrip_time_pattern.finditer(content))
         if len(timestamps) == 0:
             return self._no_resolver
@@ -64,14 +64,14 @@ class Fixer(generic_utils.InterruptibleProcess):
 
         return self._no_resolver
 
-    def _fix_subtitle(self, broken_subtitle: str, video_info: video_utils.VideoInfo) -> bool:
-        video_track = video_info.video_tracks[0]
+    def _fix_subtitle(self, broken_subtitle: str, video_info: dict) -> bool:
+        video_track = video_info["video"][0]
 
         with open(broken_subtitle, 'r', encoding='utf-8') as file:
             content = file.read()
 
         # figure out what is broken
-        resolver = self._get_resolver(content, video_track.length)
+        resolver = self._get_resolver(content, video_track["length"])
         new_content = resolver(video_track, content)
 
         if new_content is None:
@@ -82,22 +82,22 @@ class Fixer(generic_utils.InterruptibleProcess):
                 file.write(new_content)
             return True
 
-    def _extract_all_subtitles(self, video_file: str, subtitles: list[subtitles_utils.Subtitle], wd: str) -> list[subtitles_utils.SubtitleFile]:
+    def _extract_all_subtitles(self, video_file: str, subtitles: list[dict], wd: str) -> list[subtitles_utils.SubtitleFile]:
         result = []
         options = ["tracks", video_file]
 
         for subtitle in subtitles:
-            outputfile = f"{wd}/{subtitle.tid}.srt"
-            subtitleFile = subtitles_utils.SubtitleFile(path=outputfile, language=subtitle.language, encoding="utf8")
+            outputfile = f"{wd}/{subtitle['tid']}.srt"
+            subtitleFile = subtitles_utils.SubtitleFile(path=outputfile, language=subtitle['language'], encoding="utf8")
 
             result.append(subtitleFile)
-            options.append(f"{subtitle.tid}:{outputfile}")
+            options.append(f"{subtitle['tid']}:{outputfile}")
 
         process_utils.start_process("mkvextract", options)
 
         return result
 
-    def _repair_videos(self, broken_videos_info: list[tuple[video_utils.VideoInfo, list[int]]]) -> None:
+    def _repair_videos(self, broken_videos_info: list[tuple[dict, list[int]]]) -> None:
         self._print_broken_videos(broken_videos_info)
         self.logger.info("Fixing videos")
 
@@ -109,10 +109,10 @@ class Fixer(generic_utils.InterruptibleProcess):
                 broken_subtitiles = broken_video[1]
 
                 with tempfile.TemporaryDirectory() as wd_dir:
-                    video_file = video_info.path
+                    video_file = video_info["path"]
                     self.logger.info(f"Fixing subtitles in file {video_file}")
                     self.logger.debug("Extracting subtitles from file")
-                    subtitles = self._extract_all_subtitles(video_file, video_info.subtitles, wd_dir)
+                    subtitles = self._extract_all_subtitles(video_file, video_info.get("subtitle", []), wd_dir)
                     broken_subtitles_paths = [subtitles[i] for i in broken_subtitiles]
 
                     status = all(self._fix_subtitle(broken_subtitile.path, video_info) for broken_subtitile in broken_subtitles_paths)
@@ -139,14 +139,15 @@ class Fixer(generic_utils.InterruptibleProcess):
                     else:
                         self.logger.debug("Skipping video due to errors")
 
-    def _check_if_broken(self, video_file: str) -> tuple[video_utils.VideoInfo, list[int]] | None:
+    def _check_if_broken(self, video_file: str) -> tuple[dict, list[int]] | None:
         self.logger.debug(f"Processing file {video_file}")
 
         def diff(a, b):
             return abs(a - b) / max(a, b)
 
         video_info = video_utils.get_video_data(video_file)
-        video_length = video_info.video_tracks[0].length
+        video_info["path"] = video_file
+        video_length = video_info["video"][0]["length"]
 
         if video_length is None:
             self.logger.warning(f"File {video_file} has unknown length. Cannot proceed.")
@@ -154,14 +155,14 @@ class Fixer(generic_utils.InterruptibleProcess):
 
         broken_subtitiles = []
 
-        for i in range(len(video_info.subtitles)):
-            subtitle = video_info.subtitles[i]
+        for i in range(len(video_info.get("subtitle", []))):
+            subtitle = video_info["subtitle"][i]
 
-            if not subtitle.format == "subrip":
+            if not subtitle["format"] == "subrip":
                 self.logger.warning(f"Cannot analyse subtitle #{i} of {video_file}: unsupported format '{subtitle.format}'")
                 continue
 
-            length = subtitle.length
+            length = subtitle["length"]
             if length is not None and length > video_length * 1.001:                 # use 0.1% error margin as for some reason valid subtitles may appear longer than video
                 broken_subtitiles.append(i)
 
@@ -172,7 +173,7 @@ class Fixer(generic_utils.InterruptibleProcess):
         self.logger.debug(f"Issues found in {video_file}")
         return (video_info, broken_subtitiles)
 
-    def _process_dir(self, path: str) -> list[tuple[video_utils.VideoInfo, list[int]]]:
+    def _process_dir(self, path: str) -> list[tuple[dict, list[int]]]:
         broken_videos = []
         video_files = []
 
@@ -210,12 +211,7 @@ class FixerTool(Tool):
 
     @override
     def run(self, args: argparse.Namespace, no_dry_run: bool, logger: logging.Logger) -> None:
-        for tool in ["mkvmerge", "mkvextract", "ffprobe"]:
-            path = shutil.which(tool)
-            if path is None:
-                raise RuntimeError(f"{tool} not found in PATH")
-            else:
-                logging.debug(f"{tool} path: {path}")
+        process_utils.ensure_tools_exist(["mkvmerge", "mkvextract", "ffprobe"], logger)
 
         logger.info("Searching for broken files")
         fixer = Fixer(logger, no_dry_run)

--- a/twotone/tools/utils/process_utils.py
+++ b/twotone/tools/utils/process_utils.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import re
+import shutil
 import subprocess
 from dataclasses import dataclass
 from tqdm import tqdm
@@ -57,3 +58,12 @@ def start_process(process: str, args: List[str], show_progress = False) -> Proce
 def raise_on_error(status: ProcessResult):
     if status.returncode != 0:
         raise RuntimeError(f"Process exited with unexpected error:\n{status.stdout}\n{status.stderr}")
+
+
+def ensure_tools_exist(tools: List[str], logger: logging.Logger) -> None:
+    """Verify that all required external tools are available."""
+    for tool in tools:
+        path = shutil.which(tool)
+        if path is None:
+            raise RuntimeError(f"{tool} not found in PATH")
+        logger.debug(f"{tool} path: {path}")

--- a/twotone/tools/utils/video_utils.py
+++ b/twotone/tools/utils/video_utils.py
@@ -1,4 +1,3 @@
-
 import json
 import logging
 import os
@@ -7,33 +6,13 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Union, Tuple
 
-from dataclasses import dataclass
+
 
 from . import language_utils, process_utils
 from .generic_utils import fps_str_to_float, time_to_ms
 from .subtitles_utils import SubtitleFile
 
 
-@dataclass
-class VideoTrack:
-    fps: str
-    length: int
-
-
-@dataclass
-class Subtitle:
-    language: str
-    default: int | bool
-    length: int | None
-    tid: int
-    format: str
-
-
-@dataclass
-class VideoInfo:
-    video_tracks: List[VideoTrack]
-    subtitles: List[Subtitle]
-    path: str
 
 
 def is_video(file: str) -> bool:
@@ -230,26 +209,25 @@ def get_video_full_info(path: str) -> dict:
     return output_json
 
 
-def get_video_data2(path: str) -> Dict:
+def _get_length(stream) -> int | None:
+    """Return stream length in milliseconds if available."""
+    length = None
 
-    def get_length(stream) -> int | None:
-        """
-            get length in milliseconds
-        """
-        length = None
+    if "tags" in stream:
+        tags = stream["tags"]
+        duration = tags.get("DURATION", None)
+        if duration is not None:
+            length = time_to_ms(duration)
 
-        if "tags" in stream:
-            tags = stream["tags"]
-            duration = tags.get("DURATION", None)
-            if duration is not None:
-                length = time_to_ms(duration)
+    if length is None:
+        length = stream.get("duration", None)
+        if length is not None:
+            length = int(float(length) * 1000)
 
-        if length is None:
-            length = stream.get("duration", None)
-            if length is not None:
-                length = int(float(length) * 1000)
+    return length
 
-        return length
+
+def get_video_data(path: str) -> Dict:
 
     def get_language(stream) -> Union[str | None]:
         if "tags" in stream:
@@ -268,7 +246,7 @@ def get_video_data2(path: str) -> Dict:
         if stream_type == "subtitle":
             language = get_language(stream)
             is_default = stream["disposition"]["default"]
-            length = get_length(stream)
+            length = _get_length(stream)
             tid = stream["index"]
             format = stream["codec_name"]
 
@@ -280,7 +258,7 @@ def get_video_data2(path: str) -> Dict:
                 "format": format})
         elif stream_type == "video":
             fps = stream["r_frame_rate"]
-            length = get_length(stream)
+            length = _get_length(stream)
             if length is None:
                 length = get_video_duration(path)
 
@@ -313,61 +291,15 @@ def get_video_data2(path: str) -> Dict:
     return dict(streams)
 
 
-def get_video_data(path: str) -> VideoInfo:
-
-    def get_length(stream) -> int | None:
-        """get length in milliseconds"""
-        length = None
-
-        if "tags" in stream:
-            tags = stream["tags"]
-            duration = tags.get("DURATION", None)
-            if duration is not None:
-                length = time_to_ms(duration)
-
-        if length is None:
-            length = stream.get("duration", None)
-            if length is not None:
-                length = int(float(length) * 1000)
-
-        return length
-
-    output_json = get_video_full_info(path)
-
-    subtitles: List[Subtitle] = []
-    video_tracks: List[VideoTrack] = []
-    for stream in output_json["streams"]:
-        stream_type = stream["codec_type"]
-        if stream_type == "subtitle":
-            if "tags" in stream:
-                tags = stream["tags"]
-                language = tags.get("language", None)
-            else:
-                language = None
-            is_default = stream["disposition"]["default"]
-            length = get_length(stream)
-            tid = stream["index"]
-            format = stream["codec_name"]
-
-            subtitles.append(Subtitle(language, default=is_default, length=length, tid=tid, format=format))
-        elif stream_type == "video":
-            fps = stream["r_frame_rate"]
-            length = get_length(stream)
-            if length is None:
-                length = get_video_duration(path)
-
-            video_tracks.append(VideoTrack(fps=fps, length=length))
-
-    return VideoInfo(video_tracks, subtitles, path)
 
 
-def compare_videos(lhs: List[VideoTrack], rhs: List[VideoTrack]) -> bool:
+def compare_videos(lhs: List[Dict], rhs: List[Dict]) -> bool:
     if len(lhs) != len(rhs):
         return False
 
     for lhs_item, rhs_item in zip(lhs, rhs):
-        lhs_fps = fps_str_to_float(lhs_item.fps)
-        rhs_fps = fps_str_to_float(rhs_item.fps)
+        lhs_fps = fps_str_to_float(lhs_item["fps"])
+        rhs_fps = fps_str_to_float(rhs_item["fps"])
 
         if lhs_fps == rhs_fps:
             return True
@@ -442,7 +374,7 @@ def generate_mkv(output_path: str, input_video: str, subtitles: List[SubtitleFil
     output_file_details = get_video_data(output_path)
     input_file_details = get_video_data(input_video)
 
-    if not compare_videos(input_file_details.video_tracks, output_file_details.video_tracks) or \
-            len(input_file_details.subtitles) + len(subtitles) != len(output_file_details.subtitles):
+    if not compare_videos(input_file_details["video"], output_file_details["video"]) or \
+            len(input_file_details.get("subtitle", [])) + len(subtitles) != len(output_file_details.get("subtitle", [])):
         logging.error("Output file seems to be corrupted")
         raise RuntimeError("mkvmerge created a corrupted file")


### PR DESCRIPTION
## Summary
- deduplicate `Subtitle` data class
- extract `_get_length` helper for video stream parsing
- share tool availability checks with `ensure_tools_exist`
- switch to improved `get_video_data` API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for optional deps)*

------
https://chatgpt.com/codex/tasks/task_e_68615680f89083318343bf6a45852363