### PR TITLE
Unify test logging setup

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1,6 +1,7 @@
 
 import hashlib
 import inspect
+import logging
 import os
 import re
 import shutil
@@ -62,9 +63,16 @@ class WorkingDirectoryForTest:
         shutil.rmtree(self.directory)
 
 
-class WorkingDirectoryTestCase(unittest.TestCase):
+class TwoToneTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        logging.getLogger().setLevel(logging.CRITICAL)
+        cls.logger = logging.getLogger(cls.__name__)
+
     def setUp(self):
         super().setUp()
+        self.logger = self.__class__.logger
         self.wd = WorkingDirectoryForTest(self.__class__.__name__, self._testMethodName)
         self.wd.__enter__()
 

--- a/tests/test_concatenate.py
+++ b/tests/test_concatenate.py
@@ -6,11 +6,10 @@ import unittest
 from typing import List
 
 from twotone.tools.utils.files_utils import split_path
-from common import WorkingDirectoryTestCase, add_test_media, list_files, run_twotone
+from common import TwoToneTestCase, add_test_media, list_files, run_twotone
 
 
-class ConcatenateTests(WorkingDirectoryTestCase):
-
+class ConcatenateTests(TwoToneTestCase):
     def _create_media(self, wd: str, base_file: str, partnames: List[str]):
         media_file_components = split_path(base_file)
 
@@ -99,5 +98,4 @@ class ConcatenateTests(WorkingDirectoryTestCase):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(format='%(asctime)s - %(message)s', level=logging.CRITICAL)
     unittest.main()

--- a/tests/test_melt.py
+++ b/tests/test_melt.py
@@ -13,7 +13,7 @@ from twotone.tools.utils import generic_utils, process_utils, video_utils
 from twotone.tools.melt import Melter
 from twotone.tools.melt.melt import StaticSource, StreamsPicker
 from twotone.tools.utils.files_utils import ScopedDirectory
-from common import WorkingDirectoryTestCase, FileCache, add_test_media, add_to_test_dir, current_path, get_audio, get_video, hashes, list_files
+from common import TwoToneTestCase, FileCache, add_test_media, add_to_test_dir, current_path, get_audio, get_video, hashes, list_files
 
 
 def normalize(obj):
@@ -36,12 +36,7 @@ def all_key_orders(d: Dict) -> Iterator[Dict]:
         yield {k: d[k] for k in perm}
 
 
-class MeltingTest(WorkingDirectoryTestCase):
-
-    def setUp(self):
-        super().setUp()
-        logging.getLogger("Melter").setLevel(logging.CRITICAL)
-
+class MeltingTest(TwoToneTestCase):
     def test_simple_duplicate_detection(self):
         file1 = add_test_media("Grass - 66810.mp4", self.wd.path, suffixes = ["v1"])[0]
         file2 = add_test_media("Grass - 66810.mp4", self.wd.path, suffixes = ["v2"])[0]
@@ -57,7 +52,7 @@ class MeltingTest(WorkingDirectoryTestCase):
         output_dir = os.path.join(self.wd.path, "output")
         os.makedirs(output_dir)
 
-        melter = Melter(logging.getLogger("Melter"), interruption, duplicates, live_run = True, wd = self.wd.path, output = output_dir)
+        melter = Melter(self.logger.getChild("Melter"), interruption, duplicates, live_run = True, wd = self.wd.path, output = output_dir)
         melter.melt()
 
         # expect output to be equal to the first of files
@@ -83,7 +78,7 @@ class MeltingTest(WorkingDirectoryTestCase):
         output_dir = os.path.join(self.wd.path, "output")
         os.makedirs(output_dir)
 
-        melter = Melter(logging.getLogger("Melter"), interruption, duplicates, live_run = False, wd = self.wd.path, output = output_dir)
+        melter = Melter(self.logger.getChild("Melter"), interruption, duplicates, live_run = False, wd = self.wd.path, output = output_dir)
         melter.melt()
 
         # expect output to be empty
@@ -177,7 +172,7 @@ class MeltingTest(WorkingDirectoryTestCase):
         output_dir = os.path.join(self.wd.path, "output")
         os.makedirs(output_dir)
 
-        melter = Melter(logging.getLogger("Melter"), interruption, duplicates, live_run = True, wd = self.wd.path, output = output_dir)
+        melter = Melter(self.logger.getChild("Melter"), interruption, duplicates, live_run = True, wd = self.wd.path, output = output_dir)
         melter.melt()
 
         # validate output
@@ -220,7 +215,7 @@ class MeltingTest(WorkingDirectoryTestCase):
         output_dir = os.path.join(self.wd.path, "output")
         os.makedirs(output_dir)
 
-        melter = Melter(logging.getLogger("Melter"), interruption, duplicates, live_run = True, wd = self.wd.path, output = output_dir)
+        melter = Melter(self.logger.getChild("Melter"), interruption, duplicates, live_run = True, wd = self.wd.path, output = output_dir)
         melter.melt()
 
         # validate output
@@ -254,7 +249,7 @@ class MeltingTest(WorkingDirectoryTestCase):
         output_dir = os.path.join(self.wd.path, "output")
         os.makedirs(output_dir)
 
-        melter = Melter(logging.getLogger("Melter"), interruption, duplicates, live_run = True, wd = self.wd.path, output = output_dir, languages_priority = ["de", "jpn", "eng", "no", "pl"])
+        melter = Melter(self.logger.getChild("Melter"), interruption, duplicates, live_run = True, wd = self.wd.path, output = output_dir, languages_priority = ["de", "jpn", "eng", "no", "pl"])
         melter.melt()
 
         # validate order
@@ -358,7 +353,7 @@ class MeltingTest(WorkingDirectoryTestCase):
     def test_streams_pick_decision(self, name, input, expected_streams):
         interruption = generic_utils.InterruptibleProcess()
         duplicates = StaticSource(interruption)
-        streams_picker = StreamsPicker(logging.getLogger("Melter"), duplicates)
+        streams_picker = StreamsPicker(self.logger.getChild("Melter"), duplicates)
 
         # Test all possible combinations of order of input files. Output should be stable
         for video_info in all_key_orders(input):

--- a/tests/test_merge_errors_reaction.py
+++ b/tests/test_merge_errors_reaction.py
@@ -1,15 +1,8 @@
-import logging
 import unittest
 
-from common import WorkingDirectoryTestCase, add_test_media, hashes, run_twotone, simulate_process_failure
+from common import TwoToneTestCase, add_test_media, hashes, run_twotone, simulate_process_failure
 
-class SimpleSubtitlesMerge(WorkingDirectoryTestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        logging.getLogger().setLevel(logging.CRITICAL)
-
-
+class SimpleSubtitlesMerge(TwoToneTestCase):
     def test_no_changes_when_mkvmerge_exits_with_error(self):
         with simulate_process_failure("mkvmerge") as mock_start_process:
             add_test_media("Blue_Sky_and_Clouds_Timelapse.*(?:mov|srt)", self.wd.path)

--- a/tests/test_merge_language_detection.py
+++ b/tests/test_merge_language_detection.py
@@ -3,10 +3,10 @@ import os
 import unittest
 
 from twotone.tools.utils import video_utils
-from common import WorkingDirectoryTestCase, assert_video_info, list_files, add_test_media, run_twotone, write_subtitle
+from common import TwoToneTestCase, assert_video_info, list_files, add_test_media, run_twotone, write_subtitle
 
 
-class SimpleSubtitlesMerge(WorkingDirectoryTestCase):
+class SimpleSubtitlesMerge(TwoToneTestCase):
     def test_english_recognition(self):
         add_test_media("Frog.*mp4", self.wd.path)
 

--- a/tests/test_merge_subtitles.py
+++ b/tests/test_merge_subtitles.py
@@ -5,7 +5,7 @@ import re
 import unittest
 
 from twotone.tools.utils import files_utils, video_utils
-from common import WorkingDirectoryTestCase, assert_video_info, list_files, add_test_media, hashes, run_twotone, write_subtitle
+from common import TwoToneTestCase, assert_video_info, list_files, add_test_media, hashes, run_twotone, write_subtitle
 
 
 default_video_set = [
@@ -39,12 +39,7 @@ def get_default_media_set_regex():
     return filter
 
 
-class SubtitlesMerge(WorkingDirectoryTestCase):
-
-    def setUp(self):
-        super().setUp()
-        logging.getLogger().setLevel(logging.ERROR)
-
+class SubtitlesMerge(TwoToneTestCase):
     def test_dry_run_is_respected(self):
         add_test_media(get_default_media_set_regex(), self.wd.path)
 
@@ -204,7 +199,6 @@ class SubtitlesMerge(WorkingDirectoryTestCase):
         assert_video_info(self, video, expected_subtitles=4)
 
     def test_appending_subtitles_to_mkv_with_subtitles(self):
-
         # combine mp4 with srt into mkv
         add_test_media("fog-over-mountainside.*(mp4|srt)", self.wd.path)
 
@@ -225,7 +219,6 @@ class SubtitlesMerge(WorkingDirectoryTestCase):
         self.assertEqual(tracks.subtitles[1].language, "pol")
 
     def test_two_videos_one_subtitle(self):
-
         # create mkv file
         add_test_media("Woman.*(mp4|srt)", self.wd.path)
         run_twotone("merge", [self.wd.path], ["--no-dry-run"])

--- a/tests/test_merge_subtitles_conversion.py
+++ b/tests/test_merge_subtitles_conversion.py
@@ -3,13 +3,11 @@ import os
 import unittest
 
 from twotone.tools.utils import process_utils, subtitles_utils, generic_utils
-from common import WorkingDirectoryTestCase, list_files, add_test_media, generate_microdvd_subtitles, run_twotone, extract_subtitles
+from common import TwoToneTestCase, list_files, add_test_media, generate_microdvd_subtitles, run_twotone, extract_subtitles
 
 
-class SubtitlesConversion(WorkingDirectoryTestCase):
-
+class SubtitlesConversion(TwoToneTestCase):
     def test_microdvd_subtitles_with_nondefault_fps(self):
-
         add_test_media("sea-waves-crashing-on-beach-shore.*mp4", self.wd.path)
         generate_microdvd_subtitles(os.path.join(self.wd.path, "sea-waves.txt"), 25)
 

--- a/tests/test_subtitles_fixer.py
+++ b/tests/test_subtitles_fixer.py
@@ -6,7 +6,7 @@ import tempfile
 from twotone.tools.utils import subtitles_utils, video_utils
 
 from common import (
-    WorkingDirectoryTestCase,
+    TwoToneTestCase,
     add_test_media,
     hashes,
     current_path,
@@ -78,12 +78,7 @@ def create_broken_video_with_incompatible_subtitles(output_video_path: str, inpu
         process_utils.start_process("ffmpeg", ["-hide_banner", "-i", input_video, "-i", subtitle_path, "-map", "0", "-map", "1", "-c:v", "copy", "-c:a", "copy", output_video_path])
 
 
-class SubtitlesFixer(WorkingDirectoryTestCase):
-
-    def setUp(self):
-        super().setUp()
-        logging.getLogger().setLevel(logging.ERROR)
-
+class SubtitlesFixer(TwoToneTestCase):
     def test_dry_run_is_respected(self):
         output_video_path = f"{self.wd.path}/test_video.mkv"
         create_broken_video_with_scaled_subtitle_timings(output_video_path, f"{current_path}/videos/sea-waves-crashing-on-beach-shore-4793288.mp4")

--- a/tests/test_transcoder.py
+++ b/tests/test_transcoder.py
@@ -3,15 +3,10 @@ import unittest
 import logging
 
 from twotone.tools.transcode import Transcoder
-from common import WorkingDirectoryTestCase, get_video, add_test_media, hashes, run_twotone
+from common import TwoToneTestCase, get_video, add_test_media, hashes, run_twotone
 
 
-class TranscoderTests(WorkingDirectoryTestCase):
-
-    def setUp(self):
-        super().setUp()
-        self.logger = logging.getLogger("TranscoderTests")
-
+class TranscoderTests(TwoToneTestCase):
     def test_video_1_for_best_crf(self):
         test_video = get_video("big_buck_bunny_720p_2mb.mp4")
         best_enc = Transcoder(self.logger).find_optimal_crf(test_video, allow_segments=False)
@@ -42,7 +37,6 @@ class TranscoderTests(WorkingDirectoryTestCase):
         self.assertEqual(hashes_after, hashes_before)
 
     def test_transcoding_on_short_videos_live_run(self):
-
         # VID_20240412_181520.mp4 does not transcode properly with ffmpeg 7.0. With 7.1 it works.
         # Disable as of now
         add_test_media("VID_20240412_1815.[^0]\\.mp4", self.wd.path, copy = True)
@@ -61,5 +55,4 @@ class TranscoderTests(WorkingDirectoryTestCase):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(format='%(asctime)s - %(message)s', level=logging.ERROR)
     unittest.main()

--- a/tests/test_utilities_scenes.py
+++ b/tests/test_utilities_scenes.py
@@ -7,7 +7,7 @@ import re
 from typing import List
 
 from twotone.tools.utilities import extract_scenes
-from common import WorkingDirectoryTestCase, WorkingDirectoryForTest, get_video
+from common import TwoToneTestCase, WorkingDirectoryForTest, get_video
 
 
 def collect_files(directory: str):
@@ -56,8 +56,7 @@ def pick_first_last_sorted(files: List[str]) -> List[str]:
     return result
 
 
-class UtilitiesScenesTests(WorkingDirectoryTestCase):
-
+class UtilitiesScenesTests(TwoToneTestCase):
     def test_video_1_for_scenes_extraction(self):
         test_video = get_video("big_buck_bunny_720p_10mb.mp4")
         best_enc = extract_scenes(video_path = test_video, output_dir = self.wd.path, format = "png", scale = 10)
@@ -97,5 +96,4 @@ class UtilitiesScenesTests(WorkingDirectoryTestCase):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(format='%(asctime)s - %(message)s', level=logging.ERROR)
     unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,11 +3,10 @@ import os
 import unittest
 
 from twotone.tools.utils import subtitles_utils
-from common import WorkingDirectoryForTest, WorkingDirectoryTestCase, write_subtitle
+from common import WorkingDirectoryForTest, TwoToneTestCase, write_subtitle
 
 
-class UtilsTests(WorkingDirectoryTestCase):
-
+class UtilsTests(TwoToneTestCase):
     def _test_content(self, content: str, valid: bool):
         with WorkingDirectoryForTest() as wd:
             subtitle_path = os.path.join(wd.path, "subtitle.txt")


### PR DESCRIPTION
## Summary
- rename `WorkingDirectoryTestCase` → `TwoToneTestCase`
- centralize logging suppression in `TwoToneTestCase`
- expose `self.logger` for tests and update test suites

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6862e892ea9483318f3c12172ad7f010