### PR TITLE
Reduce tool verbosity

### DIFF
--- a/tests/test_subtitles_fixer.py
+++ b/tests/test_subtitles_fixer.py
@@ -33,7 +33,7 @@ def create_broken_video_with_scaled_subtitle_timings(output_video_path: str, inp
 
         # convert to srt format
         srt_subtitle_path = f"{subtitle_dir}/sub.srt"
-        status = process_utils.start_process("ffmpeg", ["-hide_banner", "-y", "-i", subtitle_path, srt_subtitle_path])
+        status = process_utils.start_process("ffmpeg", ["-y", "-i", subtitle_path, srt_subtitle_path])
 
         video_utils.generate_mkv(input_video = input_video, output_path = output_video_path, subtitles = [subtitles_utils.SubtitleFile(srt_subtitle_path, "eng", "utf8")])
 
@@ -75,7 +75,7 @@ def create_broken_video_with_incompatible_subtitles(output_video_path: str, inpu
         subtitle_path = f"{subtitle_dir}/sub.sub"
         generate_microdvd_subtitles(subtitle_path, int(length), fps)
 
-        process_utils.start_process("ffmpeg", ["-hide_banner", "-i", input_video, "-i", subtitle_path, "-map", "0", "-map", "1", "-c:v", "copy", "-c:a", "copy", output_video_path])
+        process_utils.start_process("ffmpeg", ["-i", input_video, "-i", subtitle_path, "-map", "0", "-map", "1", "-c:v", "copy", "-c:a", "copy", output_video_path])
 
 
 class SubtitlesFixer(TwoToneTestCase):

--- a/twotone/tools/merge.py
+++ b/twotone/tools/merge.py
@@ -141,7 +141,7 @@ class Merge(generic_utils.InterruptibleProcess):
 
             status = process_utils.start_process(
                 "ffmpeg",
-                ["-hide_banner", "-y", "-sub_charenc", encoding, "-i", input_file, output_file]
+                ["-y", "-sub_charenc", encoding, "-i", input_file, output_file]
             )
 
             if status.returncode == 0:

--- a/twotone/tools/utils/process_utils.py
+++ b/twotone/tools/utils/process_utils.py
@@ -7,10 +7,18 @@ import subprocess
 from dataclasses import dataclass
 from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
-from typing import List
+from typing import List, Dict
 
 from . import generic_utils
 from . import video_utils
+
+DEFAULT_TOOL_OPTIONS: Dict[str, List[str]] = {
+    "ffmpeg": ["-hide_banner"],
+    "ffprobe": ["-hide_banner"],
+    "mkvmerge": ["--quiet"],
+    "mkvextract": ["--quiet"],
+    "exiftool": ["-q"],
+}
 
 @dataclass
 class ProcessResult:
@@ -20,6 +28,11 @@ class ProcessResult:
 
 
 def start_process(process: str, args: List[str], show_progress = False) -> ProcessResult:
+    defaults = DEFAULT_TOOL_OPTIONS.get(process, [])
+    for opt in reversed(defaults):
+        if opt not in args:
+            args.insert(0, opt)
+
     command = [process]
     command.extend(args)
 


### PR DESCRIPTION
## Summary
- centralize default command options for tools
- auto inject quieter options when launching ffmpeg and other tools
- drop manual `-hide_banner` arguments in merge tool
- update subtitles fixer tests to rely on defaults

## Testing
- `python3 -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'pycountry')*

------
https://chatgpt.com/codex/tasks/task_e_68642fe787888331846732b55fe28c1c