### PR TITLE
Improve type hints and optional parameters

### DIFF
--- a/twotone/tools/melt/attachments_picker.py
+++ b/twotone/tools/melt/attachments_picker.py
@@ -1,15 +1,15 @@
 
 import logging
 
-from typing import Dict
+from typing import Dict, List, Tuple, Any
 
 
 class AttachmentsPicker:
     def __init__(self, logger: logging.Logger):
         self.logger = logger
 
-    def pick_attachments(self, files_details: Dict):
-        picked_attachments = []
+    def pick_attachments(self, files_details: Dict[str, List[Dict[str, Any]]]) -> List[Tuple[str, int]]:
+        picked_attachments: List[Tuple[str, int]] = []
         for file, attachments in files_details.items():
             for attachment in attachments:
                 picked_attachments.append((file, attachment["tid"]))

--- a/twotone/tools/melt/jellyfin.py
+++ b/twotone/tools/melt/jellyfin.py
@@ -4,14 +4,14 @@ import requests
 
 from collections import defaultdict
 from overrides import override
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 
 from ..utils import generic_utils
 from .duplicates_source import DuplicatesSource
 
 
 class JellyfinSource(DuplicatesSource):
-    def __init__(self, interruption: generic_utils.InterruptibleProcess, url: str, token: str, path_fix: Tuple[str, str]) -> None:
+    def __init__(self, interruption: generic_utils.InterruptibleProcess, url: str, token: str, path_fix: Optional[Tuple[str, str]] = None) -> None:
         super().__init__(interruption)
 
         self.url = url

--- a/twotone/tools/melt/streams_picker.py
+++ b/twotone/tools/melt/streams_picker.py
@@ -32,7 +32,7 @@ class StreamsPicker:
                 yield k, v
 
     @staticmethod
-    def _pick_best_file_candidate(files_details: Dict[str, Dict]):
+    def _pick_best_file_candidate(files_details: Dict[str, Dict]) -> str:
         """
             Function returns file with most streams.
         """
@@ -159,7 +159,11 @@ class StreamsPicker:
         return result
 
 
-    def pick_streams(self, files_details: Dict):
+    def pick_streams(self, files_details: Dict[str, Dict]) -> Tuple[
+        List[Tuple[str, int, Optional[str]]],
+        List[Tuple[str, int, Optional[str]]],
+        List[Tuple[str, int, Optional[str]]],
+    ]:
         # video preference comparator
         def video_cmp(lhs: Dict, rhs: Dict) -> int:
             if lhs.get("width") > rhs.get("width") and lhs.get("height") > rhs.get("height"):

--- a/twotone/tools/utils/files_utils.py
+++ b/twotone/tools/utils/files_utils.py
@@ -1,11 +1,10 @@
 
-import shutil
-
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, Iterable
 import os
 import tempfile
 import uuid
+import shutil
 
 
 def split_path(path: str) -> Tuple[str, str, str]:
@@ -18,7 +17,7 @@ class ScopedDirectory:
     def __init__(self, path: str):
         self.path = Path(path)
 
-    def __enter__(self):
+    def __enter__(self) -> Path:
         if self.path.exists():
             shutil.rmtree(self.path)
         self.path.mkdir(parents=True, exist_ok=False)
@@ -41,9 +40,9 @@ class TempFileManager:
     def __init__(self, content: str, extension: str | None = None):
         self.content = content
         self.extension = extension
-        self.filepath = None
+        self.filepath: str | None = None
 
-    def __enter__(self):
+    def __enter__(self) -> str:
         suffix = f".{self.extension}" if self.extension else ""
         with tempfile.NamedTemporaryFile(delete=False, suffix=suffix, mode="w") as temp_file:
             self.filepath = temp_file.name
@@ -55,7 +54,7 @@ class TempFileManager:
         if self.filepath and os.path.exists(self.filepath):
             os.remove(self.filepath)
 
-def get_common_prefix(paths) -> str:
+def get_common_prefix(paths: Iterable[str]) -> str:
     unified = list(paths)
     return os.path.commonpath(unified)
 

--- a/twotone/tools/utils/video_utils.py
+++ b/twotone/tools/utils/video_utils.py
@@ -19,7 +19,7 @@ def is_video(file: str) -> bool:
     return Path(file).suffix[1:].lower() in ["mkv", "mp4", "avi", "mpg", "mpeg", "mov", "rmvb"]
 
 
-def get_video_frames_count(video_file: str):
+def get_video_frames_count(video_file: str) -> int | None:
     result = process_utils.start_process("ffprobe", ["-v", "error", "-select_streams", "v:0", "-count_packets",
                                    "-show_entries", "stream=nb_read_packets", "-of", "csv=p=0", video_file])
 
@@ -179,7 +179,7 @@ def extract_all_frames(video_path: str, target_dir: str, format: str = "jpeg", s
     return mapping
 
 
-def get_video_duration(video_file):
+def get_video_duration(video_file: str) -> int | None:
     """Get the duration of a video in milliseconds."""
     result = process_utils.start_process("ffprobe", ["-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", video_file])
 


### PR DESCRIPTION
## Summary
- support optional path_fix in Jellyfin source
- type annotations for attachments picker
- add return types for stream picking helpers
- refine file utilities with proper typing
- type annotate video helper functions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'twotone')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement faust_cchardet>=2.1.19)*

------
https://chatgpt.com/codex/tasks/task_e_687f53d316a88331af62f4213e9e813e