### PR TITLE
Introduce global working directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ python -m twotone <tool-name> --help
 
 Dry Run Mode: all tools run in a dry run mode by default (no files are being modified). Use the -r or --no-dry-run global option to perform actual operation. In live run mode most tools remove their input files after successful processing.<br/>
 It is safe to stop execution with ctrl+c. All tools handle proper signal and will stop as soon as possible.<br/>
-Working Directory: use -w or --working-dir to specify where temporary and working files are created. By default the directory is taken from the operating system's user cache location for the application.<br/>
+Working Directory: use -w or --working-dir to specify where temporary and working files are created. By default the directory is taken from the operating system's user data location for the application.<br/>
 
 Data Safety: Always back up your data before using any tool, as source files may be deleted during processing.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ python -m twotone <tool-name> --help
 
 Dry Run Mode: all tools run in a dry run mode by default (no files are being modified). Use the -r or --no-dry-run global option to perform actual operation. In live run mode most tools remove their input files after successful processing.<br/>
 It is safe to stop execution with ctrl+c. All tools handle proper signal and will stop as soon as possible.<br/>
+Working Directory: use -w or --working-dir to specify where temporary and working files are created. By default the directory is taken from the operating system's user cache location for the application.<br/>
 
 Data Safety: Always back up your data before using any tool, as source files may be deleted during processing.
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -115,7 +115,7 @@ class FileCache:
         return out_path
 
 
-def list_files(path: str) -> List:
+def list_files(path: str) -> List[str]:
     results = []
 
     for root, _, files in os.walk(path):
@@ -129,6 +129,7 @@ def list_files(path: str) -> List:
 
 
 def add_test_media(filter: str, test_case_path: str, suffixes: List[str] | None = None, copy: bool = False) -> List[str]:
+    suffixes = suffixes or [""]
     filter_regex = re.compile(filter)
     output_files = []
 
@@ -139,7 +140,7 @@ def add_test_media(filter: str, test_case_path: str, suffixes: List[str] | None 
             for file in files:
                 if filter_regex.fullmatch(file):
                     for suffix in suffixes:
-                        suffix = "" if suffix is None else "-" + suffix
+                        suffix = "-" + suffix if suffix else ""
                         file_path = Path(os.path.join(root, file))
                         dst_file_name = file_path.stem + suffix + file_path.suffix
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -281,8 +281,19 @@ def extract_subtitles(video_path: str, out_path: str):
     process_utils.start_process("ffmpeg", ["-i", video_path, "-map", "0:s:0", out_path])
 
 
-def run_twotone(tool: str, tool_options = [], global_options = []):
-    global_options.append("--quiet")
+def run_twotone(tool: str, tool_options = [], global_options = None):
+    if global_options is None:
+        global_options = []
+
+    for opt in global_options:
+        if opt in ("-w", "--working-dir") or opt.startswith("--working-dir=") or opt.startswith("-w="):
+            raise ValueError("Tests must not override working directory")
+
+    wd = user_cache_dir("TwoToneTests")
+    os.makedirs(wd, exist_ok=True)
+
+    global_options.extend(["--quiet", "--working-dir", wd])
+
     twotone.twotone.execute([*global_options, tool, *tool_options])
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -289,7 +289,7 @@ def run_twotone(tool: str, tool_options = [], global_options = None):
         if opt in ("-w", "--working-dir") or opt.startswith("--working-dir=") or opt.startswith("-w="):
             raise ValueError("Tests must not override working directory")
 
-    wd = user_cache_dir("TwoToneTests")
+    wd = generic_utils.get_twotone_working_dir()
     os.makedirs(wd, exist_ok=True)
 
     global_options.extend(["--quiet", "--working-dir", wd])

--- a/tests/common.py
+++ b/tests/common.py
@@ -8,7 +8,6 @@ import shutil
 import tempfile
 import unittest
 
-
 from contextlib import contextmanager
 from pathlib import Path
 from platformdirs import user_cache_dir

--- a/tests/test_transcoder.py
+++ b/tests/test_transcoder.py
@@ -9,12 +9,12 @@ from common import TwoToneTestCase, get_video, add_test_media, hashes, run_twoto
 class TranscoderTests(TwoToneTestCase):
     def test_video_1_for_best_crf(self):
         test_video = get_video("big_buck_bunny_720p_2mb.mp4")
-        best_enc = Transcoder(self.logger).find_optimal_crf(test_video, allow_segments=False)
+        best_enc = Transcoder(self.wd.path, self.logger).find_optimal_crf(test_video, allow_segments=False)
 
         self.assertEqual(best_enc, 28)
 
     def test_video_with_segments_and_no_segments(self):
-        transcoder = Transcoder(self.logger)
+        transcoder = Transcoder(self.wd.path, self.logger)
         for test_video, crf in [(get_video("10189155-hd_1920_1080_25fps.mp4"), 27),
                                 (get_video("big_buck_bunny_720p_10mb.mp4"), 29)]:
             best_enc_segments = transcoder.find_optimal_crf(test_video, allow_segments=True)

--- a/twotone/tools/concatenate.py
+++ b/twotone/tools/concatenate.py
@@ -13,11 +13,12 @@ from twotone.tools.utils import generic_utils, process_utils, video_utils, files
 
 
 class Concatenate(generic_utils.InterruptibleProcess):
-    def __init__(self, logger: logging.Logger, live_run: bool):
+    def __init__(self, logger: logging.Logger, live_run: bool, working_dir: str):
         super().__init__()
 
         self.logger = logger
         self.live_run = live_run
+        self.working_dir = working_dir
 
     def run(self, path: str):
         self.logger.info(f"Collecting video files from path {path}")
@@ -110,7 +111,7 @@ class Concatenate(generic_utils.InterruptibleProcess):
                     return path.replace("'", "'\\''")
 
                 input_file_content = [f"file '{escape_path(input_file)}'" for input_file in input_files]
-                with files_utils.TempFileManager("\n".join(input_file_content), "txt") as input_file:
+                with files_utils.TempFileManager("\n".join(input_file_content), "txt", directory=self.working_dir) as input_file:
                     ffmpeg_args = ["-f", "concat", "-safe", "0", "-i", input_file, "-c", "copy", output]
 
                     self.logger.info(f"Concatenating files into {output} file")
@@ -145,6 +146,6 @@ class ConcatenateTool(Tool):
                             help='Path with videos to concatenate.')
 
     @override
-    def run(self, args, no_dry_run, logger: logging.Logger):
-        concatenate = Concatenate(logger, no_dry_run)
+    def run(self, args, no_dry_run, logger: logging.Logger, working_dir: str):
+        concatenate = Concatenate(logger, no_dry_run, working_dir)
         concatenate.run(args.videos_path[0])

--- a/twotone/tools/melt/melt.py
+++ b/twotone/tools/melt/melt.py
@@ -2,7 +2,6 @@
 import argparse
 import logging
 import os
-import platformdirs
 import re
 import shutil
 
@@ -594,12 +593,6 @@ class MeltTool(Tool):
                                        'No other scenarios and combinations of inputs are supported.')
 
         # global options
-        parser.add_argument('-w', '--working-dir',
-                            help="Directory for temporary files. At some scenarios, `melt` can produce enormous number of temporary files\n"
-                                 "which can occupy up to 1GB per single video's minute.\n"
-                                 "Consider using the fastest storage possible, but mind size of files.",
-                            default=os.path.join(platformdirs.user_cache_dir(), "twotone", "melt"))
-
         parser.add_argument('-o', '--output-dir',
                             help="Directory for output files")
 
@@ -622,7 +615,7 @@ class MeltTool(Tool):
 
 
     @override
-    def run(self, args, no_dry_run: bool, logger: logging.Logger):
+    def run(self, args, no_dry_run: bool, logger: logging.Logger, working_dir: str):
         interruption = generic_utils.InterruptibleProcess()
 
         data_source = None
@@ -671,7 +664,7 @@ class MeltTool(Tool):
                         interruption,
                         data_source,
                         live_run = no_dry_run,
-                        wd = args.working_dir,
+                        wd = working_dir,
                         output = args.output_dir,
                         languages_priority = languages_priority,
                         preferred_languages = preferred_languages,

--- a/twotone/tools/melt/streams_picker.py
+++ b/twotone/tools/melt/streams_picker.py
@@ -175,9 +175,9 @@ class StreamsPicker:
     def pick_streams(self, files_details: Dict):
         # video preference comparator
         def video_cmp(lhs: Dict, rhs: Dict) -> int:
-            if lhs.get("width") > rhs.get("width") and lhs.get("height") > rhs.get("height"):
+            if lhs["width"] > rhs["width"] and lhs["height"] > rhs["height"]:
                 return 1
-            if lhs.get("width") < rhs.get("width") and lhs.get("height") < rhs.get("height"):
+            if lhs["width"] < rhs["width"] and lhs["height"] < rhs["height"]:
                 return -1
 
             lhs_fps = eval(str(lhs.get("fps", "0")))

--- a/twotone/tools/merge.py
+++ b/twotone/tools/merge.py
@@ -16,12 +16,13 @@ from twotone.tools.utils import files_utils, generic_utils, process_utils, subti
 
 class Merge(generic_utils.InterruptibleProcess):
 
-    def __init__(self, logger: logging.Logger, dry_run: bool, language: str, lang_priority: str) -> None:
+    def __init__(self, logger: logging.Logger, dry_run: bool, language: str, lang_priority: str, working_dir: str) -> None:
         super().__init__()
         self.logger = logger
         self.dry_run = dry_run
         self.language = language
         self.lang_priority = [] if not lang_priority or lang_priority == "" else lang_priority.split(",")
+        self.working_dir = working_dir
 
     def _build_subtitle_from_path(self, path: str) -> subtitles_utils.SubtitleFile:
         language = None if self.language == "auto" else self.language
@@ -184,7 +185,7 @@ class Merge(generic_utils.InterruptibleProcess):
         sorted_subtitles = self._sort_subtitles(subtitles)
         sorted_subtitles_str = ", ".join([subtitle.language if subtitle.language is not None else "unknown" for subtitle in sorted_subtitles])
 
-        with tempfile.TemporaryDirectory() as temporary_subtitles_dir:
+        with tempfile.TemporaryDirectory(dir=self.working_dir) as temporary_subtitles_dir:
             prepared_subtitles = []
             for subtitle in sorted_subtitles:
                 self.logger.info(f"\t[{subtitle.language}]: {subtitle.path}")
@@ -296,12 +297,13 @@ class MergeTool(Tool):
                                 'the end in undefined order')
 
     @override
-    def run(self, args: argparse.Namespace, no_dry_run: bool, logger: logging.Logger) -> None:
+    def run(self, args: argparse.Namespace, no_dry_run: bool, logger: logging.Logger, working_dir: str) -> None:
         process_utils.ensure_tools_exist(["mkvmerge", "ffmpeg", "ffprobe"], logger)
 
         logger.info("Searching for movie and subtitle files to be merged")
         two_tone = Merge(logger,
                          dry_run=not no_dry_run,
                          language=args.language,
-                         lang_priority=args.languages_priority)
+                         lang_priority=args.languages_priority,
+                         working_dir=working_dir)
         two_tone.process_dir(args.videos_path[0])

--- a/twotone/tools/merge.py
+++ b/twotone/tools/merge.py
@@ -185,30 +185,30 @@ class Merge(generic_utils.InterruptibleProcess):
         sorted_subtitles = self._sort_subtitles(subtitles)
         sorted_subtitles_str = ", ".join([subtitle.language if subtitle.language is not None else "unknown" for subtitle in sorted_subtitles])
 
-        with tempfile.TemporaryDirectory(dir=self.working_dir) as temporary_subtitles_dir:
-            prepared_subtitles = []
-            for subtitle in sorted_subtitles:
-                self.logger.info(f"\t[{subtitle.language}]: {subtitle.path}")
-                input_files.append(subtitle.path)
+        temporary_subtitles_dir = self.working_dir
+        prepared_subtitles = []
+        for subtitle in sorted_subtitles:
+            self.logger.info(f"\t[{subtitle.language}]: {subtitle.path}")
+            input_files.append(subtitle.path)
 
-                # Subtitles are buggy sometimes, use ffmpeg to fix them.
-                # Also makemkv does not handle MicroDVD subtitles, so convert all to SubRip.
-                fps = input_file_details["video"][0]["fps"]
-                converted_subtitle = self._convert_subtitle(fps, subtitle, temporary_subtitles_dir)
+            # Subtitles are buggy sometimes, use ffmpeg to fix them.
+            # Also makemkv does not handle MicroDVD subtitles, so convert all to SubRip.
+            fps = input_file_details["video"][0]["fps"]
+            converted_subtitle = self._convert_subtitle(fps, subtitle, temporary_subtitles_dir)
 
-                prepared_subtitles.append(converted_subtitle)
+            prepared_subtitles.append(converted_subtitle)
 
-            # perform
-            self.logger.debug("\tMerge in progress...")
-            if not self.dry_run:
-                video_utils.generate_mkv(input_video=input_video, output_path=temporary_output_video, subtitles=prepared_subtitles)
+        # perform
+        self.logger.debug("\tMerge in progress...")
+        if not self.dry_run:
+            video_utils.generate_mkv(input_video=input_video, output_path=temporary_output_video, subtitles=prepared_subtitles)
 
-                # Remove all inputs
-                for input in input_files:
-                    os.remove(input)
+            # Remove all inputs
+            for input in input_files:
+                os.remove(input)
 
-                # rename final file to a proper one
-                shutil.move(temporary_output_video, output_video)
+            # rename final file to a proper one
+            shutil.move(temporary_output_video, output_video)
 
         self.logger.debug("\tDone")
 

--- a/twotone/tools/tool.py
+++ b/twotone/tools/tool.py
@@ -6,5 +6,6 @@ class Tool:
     def setup_parser(self, parser: argparse.ArgumentParser):
         pass
 
-    def run(self, args: argparse.Namespace, no_dry_run: bool, logger: logging.Logger):
+    def run(self, args: argparse.Namespace, no_dry_run: bool,
+            logger: logging.Logger, working_dir: str):
         pass

--- a/twotone/tools/utilities.py
+++ b/twotone/tools/utilities.py
@@ -110,7 +110,7 @@ class UtilitiesTool(Tool):
                                       help = "Frames scale in %%. Default is 100")
 
     @override
-    def run(self, args, no_dry_run: bool, logger: logging.Logger):
+    def run(self, args, no_dry_run: bool, logger: logging.Logger, working_dir: str):
         if args.subtool == "scenes":
             extract_scenes(video_path = args.video_path[0], output_dir = args.output, format = args.format, scale = float(args.scale))
         else:

--- a/twotone/tools/utils/files_utils.py
+++ b/twotone/tools/utils/files_utils.py
@@ -38,14 +38,15 @@ def get_unique_file_name(directory: str, extension: str) -> str:
 
 
 class TempFileManager:
-    def __init__(self, content: str, extension: str | None = None):
+    def __init__(self, content: str, extension: str | None = None, directory: str | None = None):
         self.content = content
         self.extension = extension
         self.filepath = None
+        self.directory = directory
 
     def __enter__(self):
         suffix = f".{self.extension}" if self.extension else ""
-        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix, mode="w") as temp_file:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix, mode="w", dir=self.directory) as temp_file:
             self.filepath = temp_file.name
             temp_file.write(self.content)
 

--- a/twotone/tools/utils/generic_utils.py
+++ b/twotone/tools/utils/generic_utils.py
@@ -62,7 +62,7 @@ def get_key_position(d: dict, key) -> int:
 
 def get_twotone_working_dir():
     """Return the default cache directory for twotone temporary files."""
-    return platformdirs.user_cache_dir("twotone")
+    return platformdirs.user_data_dir("twotone")
 
 
 class InterruptibleProcess:

--- a/twotone/tools/utils/generic_utils.py
+++ b/twotone/tools/utils/generic_utils.py
@@ -1,6 +1,7 @@
 
 import itertools
 import logging
+import platformdirs
 import re
 import signal
 import sys
@@ -57,6 +58,11 @@ def get_key_position(d: dict, key) -> int:
         if k == key:
             return i
     raise KeyError(f"Key {key} not found")
+
+
+def get_twotone_working_dir():
+    """Return the default cache directory for twotone temporary files."""
+    return platformdirs.user_cache_dir("twotone")
 
 
 class InterruptibleProcess:

--- a/twotone/tools/utils/process_utils.py
+++ b/twotone/tools/utils/process_utils.py
@@ -35,9 +35,9 @@ def start_process(process: str, args: List[str], show_progress = False) -> Proce
     command = [process]
     command.extend(args)
 
-    logging.debug(f"Starting {process} with options: {' '.join(args)}")
-    sub_process = subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, bufsize=1, preexec_fn=os.setsid)
+    full_cmd = f"{process} {' '.join(args)}"
+    logging.debug(f"Starting {full_cmd}")
+    sub_process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, bufsize=1, preexec_fn=os.setsid)
 
     if show_progress:
         if process == "ffmpeg":
@@ -82,7 +82,8 @@ def start_process(process: str, args: List[str], show_progress = False) -> Proce
 
 def raise_on_error(status: ProcessResult):
     if status.returncode != 0:
-        raise RuntimeError(f"Process exited with unexpected error:\n{status.stdout}\n{status.stderr}")
+        error = f"Process exited with unexpected error:\n{status.stdout}\n{status.stderr}"
+        raise RuntimeError(error)
 
 
 def ensure_tools_exist(tools: List[str], logger: logging.Logger) -> None:

--- a/twotone/twotone.py
+++ b/twotone/twotone.py
@@ -5,7 +5,6 @@ import os
 import sys
 import shutil
 
-
 from overrides import override
 
 from .tools import          \

--- a/twotone/twotone.py
+++ b/twotone/twotone.py
@@ -4,7 +4,7 @@ import logging
 import os
 import sys
 import shutil
-import platformdirs
+
 
 from overrides import override
 
@@ -15,6 +15,8 @@ from .tools import          \
     subtitles_fixer,        \
     transcode,              \
     utilities
+
+from .tools.utils import generic_utils
 
 TOOLS = {
     "concatenate": (concatenate.ConcatenateTool(), "Concatenate multifile movies into one file"),
@@ -64,7 +66,7 @@ def execute(argv: list[str]) -> None:
     parser.add_argument(
         "--working-dir",
         "-w",
-        default=platformdirs.user_cache_dir("twotone"),
+        default=generic_utils.get_twotone_working_dir(),
         help="Directory for temporary files",
     )
     subparsers = parser.add_subparsers(dest="tool", help="Available tools:")


### PR DESCRIPTION
## Summary
- add `--working-dir` global option
- remove working-dir from melt tool
- plumb working directory through tools and tests
- ensure temporary files use the working dir
- document the new option
- fix run_twotone default working-dir
- create per-tool working directory and clean it up on exit
- simplify temp file handling in merge, subtitles fixer, and transcode

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'parameterized')*

------
https://chatgpt.com/codex/tasks/task_e_688377e4a9f083318a25783f0c6ee5e5