### PR TITLE
Remove keep-input-files option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ python -m twotone concatenate --help
 
 #### Combine Duplicate Videos (melt)
 
-The melt tool scans for duplicate video files and creates a single output using the best quality segments from each copy. Duplicates can be provided manually or taken from a Jellyfin server. By default all input files used to create the output are removed after a successful run. Use `--keep-input-files` to preserve them.
+The melt tool scans for duplicate video files and creates a single output using the best quality segments from each copy. Duplicates can be provided manually or taken from a Jellyfin server. Input files are kept intact by default.
 
 ```bash
 python -m twotone melt --help

--- a/tests/test_melt.py
+++ b/tests/test_melt.py
@@ -158,7 +158,7 @@ class MeltingTest(TwoToneTestCase):
         output_file_hash = hashes(output_dir)
         self.assertEqual(len(output_file_hash), 0)
 
-    def test_inputs_are_removed_by_default(self):
+    def test_inputs_are_kept_by_default(self):
         file1 = add_test_media("Grass - 66810.mp4", self.wd.path, suffixes=["r1"])[0]
         file2 = add_test_media("Grass - 66810.mp4", self.wd.path, suffixes=["r2"])[0]
 
@@ -172,27 +172,6 @@ class MeltingTest(TwoToneTestCase):
 
         melter = Melter(self.logger.getChild("Melter"), interruption, duplicates,
                         live_run=True, wd=self.wd.path, output=output_dir)
-        melter.melt()
-
-        self.assertFalse(os.path.exists(file1))
-        self.assertFalse(os.path.exists(file2))
-        self.assertEqual(len(hashes(output_dir)), 1)
-
-    def test_keep_input_files_flag(self):
-        file1 = add_test_media("Grass - 66810.mp4", self.wd.path, suffixes=["k1"])[0]
-        file2 = add_test_media("Grass - 66810.mp4", self.wd.path, suffixes=["k2"])[0]
-
-        interruption = generic_utils.InterruptibleProcess()
-        duplicates = StaticSource(interruption)
-        duplicates.add_entry("Grass", file1)
-        duplicates.add_entry("Grass", file2)
-
-        output_dir = os.path.join(self.wd.path, "output")
-        os.makedirs(output_dir)
-
-        melter = Melter(self.logger.getChild("Melter"), interruption, duplicates,
-                        live_run=True, wd=self.wd.path, output=output_dir,
-                        keep_input_files=True)
         melter.melt()
 
         self.assertTrue(os.path.exists(file1))

--- a/twotone/tools/melt/melt.py
+++ b/twotone/tools/melt/melt.py
@@ -32,7 +32,7 @@ def _split_path_fix(value: str) -> List[str]:
 
 
 class Melter():
-    def __init__(self, logger: logging.Logger, interruption: generic_utils.InterruptibleProcess, duplicates_source: DuplicatesSource, live_run: bool, wd: str, output: str, languages_priority: List[str] = [], preferred_languages: List[str] = [], keep_input_files: bool = False, allow_length_mismatch: bool = False):
+    def __init__(self, logger: logging.Logger, interruption: generic_utils.InterruptibleProcess, duplicates_source: DuplicatesSource, live_run: bool, wd: str, output: str, languages_priority: List[str] = [], preferred_languages: List[str] = [], allow_length_mismatch: bool = False):
         self.logger = logger
         self.interruption = interruption
         self.duplicates_source = duplicates_source
@@ -42,7 +42,6 @@ class Melter():
         self.output = output
         self.languages_priority = [language_utils.unify_lang(language) for language in languages_priority]
         self.preferred_languages = [language_utils.unify_lang(language) for language in preferred_languages]
-        self.keep_input_files = keep_input_files
         self.allow_length_mismatch = allow_length_mismatch
 
         os.makedirs(self.wd, exist_ok=True)
@@ -595,13 +594,7 @@ class Melter():
 
                     self.logger.info(f"{output} saved.")
 
-                if self.live_run and not self.keep_input_files:
-                    for file_path in files:
-                        try:
-                            os.remove(file_path)
-                            self.logger.info(f"Removed input file {file_path}")
-                        except OSError as e:
-                            self.logger.warning(f"Failed to remove {file_path}: {e}")
+                # keep input files intact
 
     def melt(self):
         with files_utils.ScopedDirectory(self.wd) as wd, logging_redirect_tqdm():
@@ -669,9 +662,6 @@ class MeltTool(Tool):
                                  'For example for value: jp,pl,de melt will set default audio track to japanese or polish or german in given order if audio track in given language exists.\n'
                                  'If audio for given languages was not found, `melt` will look for subtitles in given languages and set the first one found to default.\n'
                                  'If this parameter is not set, first audio track will be chosen, and none of the subtitles will be set as default.')
-        parser.add_argument('--keep-input-files',
-                            action='store_true',
-                            help='Do not delete input files after successful processing.')
         parser.add_argument('--allow-length-mismatch', action='store_true',
                             help='Continue processing even if input video lengths differ.\n'
                                  'This may require additional processing that can consume significant time and disk space.')
@@ -731,7 +721,6 @@ class MeltTool(Tool):
                         output = args.output_dir,
                         languages_priority = languages_priority,
                         preferred_languages = preferred_languages,
-                        keep_input_files = args.keep_input_files,
                         allow_length_mismatch = args.allow_length_mismatch
         )
 


### PR DESCRIPTION
## Summary
- stop deleting inputs in melt
- clean up tests for new default behaviour
- drop keep-input-files CLI option
- update docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'twotone')*

------
https://chatgpt.com/codex/tasks/task_e_6888e56b655083319968bdc3941c766c