### PR TITLE
feat: annotate alternate subtitles

### DIFF
--- a/tests/test_merge_subtitles.py
+++ b/tests/test_merge_subtitles.py
@@ -138,9 +138,9 @@ class SubtitlesMerge(TwoToneTestCase):
 
         video = files_after[0]
         tracks = assert_video_info(self, video, expected_subtitles=2)
-        names = [track.get("name") for track in tracks["subtitle"]]
-        self.assertIn("commentary by director", names)
-        self.assertIn(None, names)
+        titles = [track.get("title") for track in tracks["subtitle"]]
+        self.assertIn("commentary by director", titles)
+        self.assertIn(None, titles)
 
     def test_no_comment_when_subtitle_names_similar(self):
         add_test_media("Atoms.*mp4", self.wd.path)

--- a/tests/test_merge_subtitles.py
+++ b/tests/test_merge_subtitles.py
@@ -119,6 +119,44 @@ class SubtitlesMerge(TwoToneTestCase):
         video = files_after[0]
         assert_video_info(self, video, expected_subtitles=3)
 
+    def test_comment_added_for_subtitles_with_different_name(self):
+        add_test_media("Atoms.*mp4", self.wd.path)
+        add_test_media("Atoms.*srt", self.wd.path)
+
+        write_subtitle(
+            os.path.join(self.wd.path, "commentary by director.srt"),
+            [
+                "00:00:00:Hello",
+                "00:00:06:Commentary",
+            ],
+        )
+
+        run_twotone("merge", [self.wd.path, "-l", "eng"], ["--no-dry-run"])
+
+        files_after = list_files(self.wd.path)
+        self.assertEqual(len(files_after), 1)
+
+        video = files_after[0]
+        tracks = assert_video_info(self, video, expected_subtitles=2)
+        names = [track.get("name") for track in tracks["subtitle"]]
+        self.assertIn("commentary by director", names)
+        self.assertIn(None, names)
+
+    def test_no_comment_when_subtitle_names_similar(self):
+        add_test_media("Atoms.*mp4", self.wd.path)
+        add_test_media("Atoms.*srt", self.wd.path)
+        add_test_media("Atoms.*srt", self.wd.path, ["director"])
+
+        run_twotone("merge", [self.wd.path, "-l", "eng"], ["--no-dry-run"])
+
+        files_after = list_files(self.wd.path)
+        self.assertEqual(len(files_after), 1)
+
+        video = files_after[0]
+        tracks = assert_video_info(self, video, expected_subtitles=2)
+        for track in tracks["subtitle"]:
+            self.assertIsNone(track.get("name"))
+
     def test_raw_txt_subtitles_conversion(self):
         # Allow automatic txt to srt conversion
         add_test_media("herd-of-horses-in-fog.*(mp4|txt)", self.wd.path)

--- a/twotone/tools/merge.py
+++ b/twotone/tools/merge.py
@@ -200,7 +200,10 @@ class Merge(generic_utils.InterruptibleProcess):
         temporary_subtitles_dir = self.working_dir
         prepared_subtitles = []
         for subtitle in sorted_subtitles:
-            self.logger.info(f"\t[{subtitle.language}]: {subtitle.path}")
+            if subtitle.comment:
+                self.logger.info(f"\t[{subtitle.language}][{subtitle.comment}]: {subtitle.path}")
+            else:
+                self.logger.info(f"\t[{subtitle.language}]: {subtitle.path}")
             input_files.append(subtitle.path)
 
             # Subtitles are buggy sometimes, use ffmpeg to fix them.

--- a/twotone/tools/merge.py
+++ b/twotone/tools/merge.py
@@ -190,7 +190,7 @@ class Merge(generic_utils.InterruptibleProcess):
         for s in sorted_subtitles:
             subtitles_by_lang[s.language].append(s)
 
-        for lang, subs in subtitles_by_lang.items():
+        for _, subs in subtitles_by_lang.items():
             if len(subs) > 1:
                 for s in subs:
                     subtitle_name = Path(s.path).stem

--- a/twotone/tools/utils/subtitles_utils.py
+++ b/twotone/tools/utils/subtitles_utils.py
@@ -18,6 +18,7 @@ class SubtitleFile:
     path: str
     language: str
     encoding: str
+    comment: str | None = None
 
 
 @dataclass

--- a/twotone/tools/utils/video_utils.py
+++ b/twotone/tools/utils/video_utils.py
@@ -419,6 +419,7 @@ def get_video_data_mkvmerge(path: str, enrich: bool = False) -> Dict:
                     "tid": tid,
                     "uid": uid,
                     "format": track.get("codec"),
+                    "name": props.get("track_name"),
                 })
             )
 
@@ -498,6 +499,9 @@ def generate_mkv(output_path: str, input_video: str, subtitles: List[SubtitleFil
 
         if lang:
             options.extend(["--language", f"0:{lang}"])
+
+        if subtitle.comment:
+            options.extend(["--track-name", f"0:{subtitle.comment}"])
 
         if i == 0:
             options.extend(["--default-track", "0:yes"])

--- a/twotone/tools/utils/video_utils.py
+++ b/twotone/tools/utils/video_utils.py
@@ -248,12 +248,14 @@ def get_video_data(path: str) -> Dict:
             is_default = stream["disposition"]["default"]
             length = get_length(stream)
             format = stream["codec_name"]
+            title = stream.get("tags", {}).get("title", None)
 
             streams["subtitle"].append({
                 "language": language,
                 "default": is_default,
                 "length": length,
                 "tid": tid,
+                "title": title,
                 "format": format})
         elif stream_type == "video":
             fps = stream["r_frame_rate"]


### PR DESCRIPTION
## Summary
- add subtitle track comments when multiple same-language subs exist
- support optional comment in subtitles utils and mkv generation
- add coverage for alternate subtitle naming

## Testing
- `PYTHONPATH=/workspace/TwoTone pytest tests/test_merge_subtitles.py::SubtitlesMerge::test_comment_added_for_subtitles_with_different_name -vv` *(fails: mkvmerge not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_689f8156f6588331a7db97a872932207