### PR TITLE
ci: enable tests on windows and macos

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,5 +1,5 @@
 
-name: Linux-unittests
+name: unittests
 
 on:
   push:
@@ -9,7 +9,10 @@ on:
 
 jobs:
   Tests:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v3
@@ -22,14 +25,26 @@ jobs:
       with:
         path: "requirements.txt"
 
-    - name: Install required tools
+    - name: Install required tools (Linux)
+      if: runner.os == 'Linux'
       run: |
-        sudo apt-get update &&  \
-        sudo apt-get install    \
-          exiftool              \
-          ffmpeg                \
+        sudo apt-get update && \
+        sudo apt-get install \
+          exiftool \
+          ffmpeg \
           mkvtoolnix
+
+    - name: Install required tools (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew update && \
+        brew install exiftool ffmpeg mkvtoolnix
+
+    - name: Install required tools (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        choco install -y exiftool ffmpeg mkvtoolnix
 
     - name: Run unit tests
       run: |
-        python3 -m unittest discover tests
+        python -m unittest discover tests


### PR DESCRIPTION
## Summary
- run unit tests on Ubuntu, macOS, and Windows
- install required tools for each platform

## Testing
- `python -m unittest discover tests` *(fails: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a052fc69b483319a62a1419a1c6788